### PR TITLE
Add reply chain creation API & SDK method

### DIFF
--- a/botbuilder-teams-js/src/schema/models/index.ts
+++ b/botbuilder-teams-js/src/schema/models/index.ts
@@ -1237,6 +1237,38 @@ export interface AppBasedLinkQuery {
 
 /**
  * @interface
+ * An interface representing TeamsCreateReplyChainRequest.
+ */
+export interface TeamsCreateReplyChainRequest {
+  /**
+   * @member {Activity} [activity]
+   */
+  activity?: builder.Activity;
+  /**
+   * @member {TeamsChannelData} [channelData]
+   */
+  channelData?: TeamsChannelData;
+}
+
+/**
+ * @interface
+ * An interface representing CreateReplyChainCreatedResponse.
+ */
+export interface CreateReplyChainCreatedResponse {
+  /**
+   * @member {string} [id] Conversation id with message id for the created new
+   * reply chain.
+   */
+  id?: string;
+  /**
+   * @member {string} [activityId] builder.Activity id for the new message (resource
+   * response)
+   */
+  activityId?: string;
+}
+
+/**
+ * @interface
  * An interface representing TeamsConnectorClientOptions.
  * @extends ServiceClientOptions
  */
@@ -1426,5 +1458,24 @@ export type TeamsFetchTeamDetailsResponse = TeamDetails & {
        * The response body as parsed JSON or XML
        */
       parsedBody: TeamDetails;
+    };
+};
+
+/**
+ * Contains response data for the createReplyChain operation.
+ */
+export type TeamsCreateReplyChainResponse = CreateReplyChainCreatedResponse & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: msRest.HttpResponse & {
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: CreateReplyChainCreatedResponse;
     };
 };

--- a/botbuilder-teams-js/src/schema/models/mappers.ts
+++ b/botbuilder-teams-js/src/schema/models/mappers.ts
@@ -1846,3 +1846,49 @@ export const AppBasedLinkQuery: msRest.CompositeMapper = {
     }
   }
 };
+
+export const TeamsCreateReplyChainRequest: msRest.CompositeMapper = {
+  serializedName: 'teamsCreateReplyChainRequest',
+  type: {
+    name: 'Composite',
+    className: 'TeamsCreateReplyChainRequest',
+    modelProperties: {
+      activity: {
+        serializedName: 'activity',
+        type: {
+          name: 'Composite',
+          className: 'Activity'
+        }
+      },
+      channelData: {
+        serializedName: 'channelData',
+        type: {
+          name: 'Composite',
+          className: 'TeamsChannelData'
+        }
+      }
+    }
+  }
+};
+
+export const CreateReplyChainCreatedResponse: msRest.CompositeMapper = {
+  serializedName: 'CreateReplyChainCreatedResponse',
+  type: {
+    name: 'Composite',
+    className: 'CreateReplyChainCreatedResponse',
+    modelProperties: {
+      id: {
+        serializedName: 'id',
+        type: {
+          name: 'String'
+        }
+      },
+      activityId: {
+        serializedName: 'activityId',
+        type: {
+          name: 'String'
+        }
+      }
+    }
+  }
+};

--- a/botbuilder-teams-js/src/schema/models/teamsMappers.ts
+++ b/botbuilder-teams-js/src/schema/models/teamsMappers.ts
@@ -16,4 +16,5 @@ export {
   CreateReplyChainCreatedResponse
 } from '../models/mappers';
 
+
 export * from 'botframework-connector/lib/connectorApi/models/mappers';

--- a/botbuilder-teams-js/src/schema/models/teamsMappers.ts
+++ b/botbuilder-teams-js/src/schema/models/teamsMappers.ts
@@ -7,6 +7,13 @@
 export {
   ConversationList,
   ChannelInfo,
-  TeamDetails
+  TeamDetails,
+  TeamsCreateReplyChainRequest,
+  TeamsChannelData,
+  TeamInfo,
+  NotificationInfo,
+  TenantInfo,
+  CreateReplyChainCreatedResponse
 } from '../models/mappers';
 
+export * from 'botframework-connector/lib/connectorApi/models/mappers';

--- a/botbuilder-teams-js/src/schema/operations/teams.ts
+++ b/botbuilder-teams-js/src/schema/operations/teams.ts
@@ -79,6 +79,38 @@ export class Teams {
       fetchTeamDetailsOperationSpec,
       callback) as Promise<Models.TeamsFetchTeamDetailsResponse>;
   }
+
+  /**
+   * Create new reply chain in Teams channel
+   * @summary Create new reply chain in Teams channel
+   * @param teamsCreateReplyChainRequest POST body for /v3/conversations request to create reply
+   * chain in Teams channel
+   * @param [options] The optional parameters
+   * @returns Promise<Models.TeamsCreateReplyChainResponse>
+   */
+  createReplyChain(teamsCreateReplyChainRequest: Models.TeamsCreateReplyChainRequest, options?: msRest.RequestOptionsBase): Promise<Models.TeamsCreateReplyChainResponse>;
+  /**
+   * @param teamsCreateReplyChainRequest POST body for /v3/conversations request to create reply
+   * chain in Teams channel
+   * @param callback The callback
+   */
+  createReplyChain(teamsCreateReplyChainRequest: Models.TeamsCreateReplyChainRequest, callback: msRest.ServiceCallback<Models.CreateReplyChainCreatedResponse>): void;
+  /**
+   * @param teamsCreateReplyChainRequest POST body for /v3/conversations request to create reply
+   * chain in Teams channel
+   * @param options The optional parameters
+   * @param callback The callback
+   */
+  createReplyChain(teamsCreateReplyChainRequest: Models.TeamsCreateReplyChainRequest, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.CreateReplyChainCreatedResponse>): void;
+  createReplyChain(teamsCreateReplyChainRequest: Models.TeamsCreateReplyChainRequest, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.CreateReplyChainCreatedResponse>, callback?: msRest.ServiceCallback<Models.CreateReplyChainCreatedResponse>): Promise<Models.TeamsCreateReplyChainResponse> {
+    return this.client.sendOperationRequest(
+      {
+        teamsCreateReplyChainRequest,
+        options
+      },
+      createReplyChainOperationSpec,
+      callback) as Promise<Models.TeamsCreateReplyChainResponse>;
+  }
 }
 
 // Operation Specifications
@@ -107,6 +139,25 @@ const fetchTeamDetailsOperationSpec: msRest.OperationSpec = {
   responses: {
     200: {
       bodyMapper: Mappers.TeamDetails
+    },
+    default: {}
+  },
+  serializer
+};
+
+const createReplyChainOperationSpec: msRest.OperationSpec = {
+  httpMethod: 'POST',
+  path: 'v3/conversations',
+  requestBody: {
+    parameterPath: 'teamsCreateReplyChainRequest',
+    mapper: {
+      ...Mappers.TeamsCreateReplyChainRequest,
+      required: true
+    }
+  },
+  responses: {
+    201: {
+      bodyMapper: Mappers.CreateReplyChainCreatedResponse
     },
     default: {}
   },

--- a/botbuilder-teams-js/swagger/teamsAPI.json
+++ b/botbuilder-teams-js/swagger/teamsAPI.json
@@ -85,6 +85,62 @@
         },
         "deprecated": false
       }
+    },
+
+    "/v3/conversations": {
+      "post": {
+        "tags": ["Teams"],
+        "summary": "Create new reply chain in Teams channel",
+        "description": "Create new reply chain in Teams channel",
+        "operationId": "Teams_CreateReplyChain",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json",
+          "text/json",
+          "application/xml",
+          "text/xml"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "teamsCreateReplyChainRequest",
+            "description": "POST body for /v3/conversations request to create reply chain in Teams channel",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "activity": {
+                  "$ref": "#/definitions/Activity"
+                },
+                "channelData": {
+                  "$ref": "#/definitions/TeamsChannelData"
+                }
+              }        
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Response of reply chain creation",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "description": "Conversation id with message id for the created new reply chain.",
+                  "type": "string"
+                },
+                "activityId": {
+                  "description": "Activity id for the new message (resource response)",
+                  "type": "string"
+                }
+              }        
+            }
+          }
+        },
+        "deprecated": false
+      }
     }
   },
 

--- a/samples/teams-bot/src/bot.ts
+++ b/samples/teams-bot/src/bot.ts
@@ -48,7 +48,11 @@ export class TeamsBot {
                         break;
 
                     case 'reply-chain':
-                        await adapter.createReplyChain(ctx, [{ text: 'New reply chain' }]);
+                        const replyChain: teams.TeamsCreateReplyChainResponse = await adapter.createReplyChain(ctx, { text: 'New reply chain' });
+                        await ctx.sendActivity({
+                            textFormat: 'xml',
+                            text: `<b>New reply chain created.</b><br/> Conversation id (with message id): <pre>${replyChain.id}</pre> activityId: <pre>${replyChain.activityId}</pre>`
+                        })
                         break;
 
                     case '1:1':


### PR DESCRIPTION
Add `/v3/conversations` API for Teams to create new reply cain in Teams channel where it will return the new conversation id with message id.

This PR also fixes the method of `createReplyChain()` in TeamsAdapter where it didn't return the new message id. So this PR will fix Issue #12.